### PR TITLE
[JENKINS-37741] gitlab oauth plugin:GitlabAPIException

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabRequireOrganizationMembershipACL.java
@@ -156,7 +156,8 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
                         return true;
                     }
                     if (allowGitlabWebHookPermission &&
-                            (currentUriPathEquals("gitlab-webhook") ||
+                            (currentUriPathStartsWith("/project/") ||
+                             currentUriPathEquals("gitlab-webhook") ||
                              currentUriPathEquals("gitlab-webhook/"))) {
                         log.finest("Granting READ access for gitlab-webhook url: " + requestURI());
                         return true;
@@ -181,6 +182,11 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
             //
             return false;
         }
+    }
+    
+    private boolean currentUriPathStartsWith( String specificPath){
+        String requestUri = requestURI();
+        return requestUri==null?false:requestUri.startsWith(specificPath);
     }
 
     private boolean currentUriPathEquals( String specificPath ) {

--- a/src/main/java/org/jenkinsci/plugins/GitLabRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabRequireOrganizationMembershipACL.java
@@ -134,7 +134,6 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
                     }
                 }
             }
-
             // no match.
             return false;
         } else {
@@ -145,12 +144,10 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
                 log.finest("Granting Full rights to SYSTEM user.");
                 return true;
             }
-
             if (authenticatedUserName.equals("anonymous")) {
                 if(checkJobStatusPermission(permission) && allowAnonymousJobStatusPermission) {
                     return true;
                 }
-
                 if (checkReadPermission(permission)) {
                     if (allowAnonymousReadPermission) {
                         return true;
@@ -167,6 +164,16 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
                         return true;
                     }
                     log.finer("Denying anonymous READ permission to url: " + requestURI());
+                }
+
+                if (testBuildPermission(permission)) {
+                    if (allowGitlabWebHookPermission &&
+                            (currentUriPathStartsWith("/project/") ||
+                             currentUriPathEquals("gitlab-webhook") ||
+                             currentUriPathEquals("gitlab-webhook/"))) {
+                        log.finest("Granting BUILD access for gitlab-webhook url: " + requestURI());
+                        return true;
+                    }
                 }
                 return false;
             }


### PR DESCRIPTION
I solved adding the test condition below

```java
class GitLabRequireOrganizationMembershipACL
public boolean hasPermission(Authentication a, Permission permission) {
{

...
                if (testBuildPermission(permission)) {
                    if (allowGitlabWebHookPermission &&
                            (currentUriPathStartsWith("/project/") ||
                             currentUriPathEquals("gitlab-webhook") ||
                             currentUriPathEquals("gitlab-webhook/"))) {
                        log.finest("Granting BUILD access for gitlab-webhook url: " + requestURI());
                        return true;
                    }
                }
}
```