### PR TITLE
Fixed IndexOutOfBoundsException when user has no group

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
@@ -298,10 +298,8 @@ public class GitLabAuthenticationToken extends AbstractAuthenticationToken {
 
 	public GitlabGroup loadOrganization(String organization) {
 		try {
-			if (gitLabAPI != null && isAuthenticated())
-			 {
-				return gitLabAPI.getGroups().get(0); // FIXME return the right
-														// group;
+			if (gitLabAPI != null && isAuthenticated() && !gitLabAPI.getGroups().isEmpty()) {
+				return gitLabAPI.getGroups().get(0); // FIXME return the right group;
 			}
 		} catch (IOException e) {
 			LOGGER.log(Level.FINEST, e.getMessage(), e);


### PR DESCRIPTION
The error we observed while adding user without a group to project authorization matrix:

![error](https://cloud.githubusercontent.com/assets/14965615/25957021/9e9cb686-366d-11e7-8d1f-a7ef9cf38fb9.png)

`java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:653)
	at java.util.ArrayList.get(ArrayList.java:429)
	at org.jenkinsci.plugins.GitLabAuthenticationToken.loadOrganization(GitLabAuthenticationToken.java:303)
	at org.jenkinsci.plugins.GitLabSecurityRealm.loadUserByUsername(GitLabSecurityRealm.java:518)
	at hudson.security.GlobalMatrixAuthorizationStrategy$DescriptorImpl.doCheckName_(GlobalMatrixAuthorizationStrategy.java:391)
	at hudson.security.AuthorizationMatrixProperty$DescriptorImpl.doCheckName(AuthorizationMatrixProperty.java:198)
	at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:343)
	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:184)
	at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:117)`

Added safety check of user's groups list.