### PR TITLE
[JENKINS-50838] Change GitLab API support from v3 to v4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.gitlab</groupId>
             <artifactId>java-gitlab-api</artifactId>
-            <version>1.2.6</version>
+            <version>4.0.0</version>
         </dependency>
 	<dependency>
             <groupId>org.jenkins-ci</groupId>

--- a/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
@@ -268,7 +268,7 @@ public class GitLabAuthenticationToken extends AbstractAuthenticationToken {
 						// could be non-existant)
 						return Boolean.FALSE;
 					} else {
-						return Boolean.valueOf(repository.isPublic());
+						return repository.isPublic();
 					}
 				}
 			});

--- a/src/main/java/org/jenkinsci/plugins/GitLabRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabRequireOrganizationMembershipACL.java
@@ -255,7 +255,7 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
                 authenticationToken.isPublicRepository(repositoryName)) {
             return true;
         } else {
-            return authenticationToken.hasRepositoryPermission(repositoryName);
+            return (permission.equals(Item.READ) || permission.equals(Item.BUILD)) && authenticationToken.hasRepositoryPermission(repositoryName);
         }
     }
 

--- a/src/main/webapp/help/realm/gitlab-api-uri-help.html
+++ b/src/main/webapp/help/realm/gitlab-api-uri-help.html
@@ -2,7 +2,7 @@
     <p>
         Normally this value stays as-is. If you are using <b><a href="https://enterprise.gitlab.com">GitLab Enterprise</a></b>
         then you should enter the URI to the <strong>API</strong> root of your GitLab installation
-        (e.g. <b>https://gitlab.company.com</b>. The plugin will automatically add "api/v3" suffix for you.).
+        (e.g. <b>https://gitlab.company.com</b>. The plugin will automatically add "api/v4" suffix for you.).
     <p/>
 
     Notes:


### PR DESCRIPTION
This PR addresses a change from the deprecated GitLab API version 3 to version 4.

This change was necessary in order to authenticate against the latest GitLab v10.7 version.