### PR TITLE
[JENKINS-52129] add 2 git URL patterns without "git@".

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitlabRepositoryName.java
+++ b/src/main/java/org/jenkinsci/plugins/GitlabRepositoryName.java
@@ -47,11 +47,13 @@ public class GitlabRepositoryName {
          * from URLs that include a '.git' suffix, removing the suffix from the
          * repository name.
          */
+        Pattern.compile("(.+):([^/]+)/([^/]+)\\.git"),
         Pattern.compile("git@(.+):([^/]+)/([^/]+)\\.git"),
         Pattern.compile("https?://[^/]+@([^/]+)/([^/]+)/([^/]+)\\.git"),
         Pattern.compile("https?://([^/]+)/([^/]+)/([^/]+)\\.git"),
         Pattern.compile("git://([^/]+)/([^/]+)/([^/]+)\\.git"),
         Pattern.compile("ssh://git@([^/]+)/([^/]+)/([^/]+)\\.git"),
+        Pattern.compile("ssh://([^/]+)/([^/]+)/([^/]+)\\.git"),
         /**
          * The second set of patterns extract the host, owner and repository names
          * from all other URLs. Note that these patterns must be processed *after*


### PR DESCRIPTION
These urls works fine with `gitlab-plugin` and `gitlab-auth-plugin v1.3`
```
git@www.example.com:grup/name.git
ssh://git@www.example.com:grup/name.git
www.example.com:grup/name.git
ssh://www.example.com:grup/name.git
```

After upgrade to gitlab-auth-plugin 1.4, these two DO NOT.
```
www.example.com:grup/name.git
ssh://www.example.com:grup/name.git

```