### PR TITLE
[JENKINS-52129] 1. bug fixed: repository.isPublic returns null.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
@@ -39,6 +39,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
 import org.acegisecurity.providers.AbstractAuthenticationToken;
@@ -48,9 +51,6 @@ import org.gitlab.api.TokenType;
 import org.gitlab.api.models.GitlabGroup;
 import org.gitlab.api.models.GitlabProject;
 import org.gitlab.api.models.GitlabUser;
-
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 import hudson.security.SecurityRealm;
 import jenkins.model.Jenkins;
@@ -268,7 +268,7 @@ public class GitLabAuthenticationToken extends AbstractAuthenticationToken {
 						// could be non-existant)
 						return Boolean.FALSE;
 					} else {
-						return repository.isPublic();
+						return Boolean.TRUE.equals(repository.isPublic());
 					}
 				}
 			});

--- a/src/main/java/org/jenkinsci/plugins/GitlabRepositoryName.java
+++ b/src/main/java/org/jenkinsci/plugins/GitlabRepositoryName.java
@@ -47,11 +47,13 @@ public class GitlabRepositoryName {
          * from URLs that include a '.git' suffix, removing the suffix from the
          * repository name.
          */
+        Pattern.compile("(.+):([^/]+)/([^/]+)\\.git"),
         Pattern.compile("git@(.+):([^/]+)/([^/]+)\\.git"),
         Pattern.compile("https?://[^/]+@([^/]+)/([^/]+)/([^/]+)\\.git"),
         Pattern.compile("https?://([^/]+)/([^/]+)/([^/]+)\\.git"),
         Pattern.compile("git://([^/]+)/([^/]+)/([^/]+)\\.git"),
         Pattern.compile("ssh://git@([^/]+)/([^/]+)/([^/]+)\\.git"),
+        Pattern.compile("ssh://([^/]+)/([^/]+)/([^/]+)\\.git"),
         /**
          * The second set of patterns extract the host, owner and repository names
          * from all other URLs. Note that these patterns must be processed *after*


### PR DESCRIPTION
repository.isPublic() returns null while guava cache loader does NOT allow this.

These urls works fine with `gitlab-plugin` and `gitlab-auth-plugin v1.3`
```
git@www.example.com:grup/name.git
ssh://git@www.example.com:grup/name.git
www.example.com:grup/name.git
ssh://www.example.com:grup/name.git
```

After upgrade to gitlab-auth-plugin 1.4, these two DO NOT.
```
www.example.com:grup/name.git
ssh://www.example.com:grup/name.git

```