### PR TITLE
Changed redirect url build using jenkins root url

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -277,7 +277,7 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
     }
 
     private String buildRedirectUrl(StaplerRequest request, String referer) throws MalformedURLException {
-        URL currentUrl = new URL(request.getRequestURL().toString());
+        URL currentUrl = new URL(Jenkins.getInstance().getRootUrl());
         List<NameValuePair> parameters = new ArrayList<NameValuePair>();
         parameters.add(new BasicNameValuePair("state", referer));
 


### PR DESCRIPTION
In presence of a reverse proxy behind jenkins the redirect url built could be wrong.
Using Jenkins.getInstance().getRootUrl() instead of request.getRequestUrl should solve the problem