### PR TITLE
[WEBSITE-637] Use GitHub as source of documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,20 @@
-
+1.5
+-----------------------------------------------------------------------------------
+ - **Bjoern Kasteleiner** : [SECURITY-795](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-795) Fix session fixation vulnerability (#16)
+ - **Wadeck Follonier** : [SECURITY-796](https://jenkins.io/security/advisory/2019-08-07/#SECURITY-796) Fix open redirect vulnerability (#17)
 
 1.4
 -----------------------------------------------------------------------------------
- - **Mario Steinitz** : [JENKINS-50838] Change GitLab API support from v3 to v4.
+ - **Mario Steinitz** : [JENKINS-50838](https://issues.jenkins-ci.org/browse/JENKINS-50838) Change GitLab API support from v3 to v4.
 
 1.3
 -----------------------------------------------------------------------------------
- - **Mohamed EL Habib** : [JENKINS-47097] added support to login using gitlab private token
+ - **Mohamed EL Habib** : [JENKINS-47097](https://issues.jenkins-ci.org/browse/JENKINS-47097) added support to login using gitlab private token
 
 1.2
 -----------------------------------------------------------------------------------
- - **Mohamed EL Habib** : [JENKINS-44489] fixed findbug introduced by 987608a commit
- - **Mohamed EL Habib** : [JENKINS-44489] fixed logout when the plugin is configured to allow READ permission for Authenticated, but not Anonymous users.
+ - **Mohamed EL Habib** : [JENKINS-44489](https://issues.jenkins-ci.org/browse/JENKINS-44489) fixed findbug introduced by 987608a commit
+ - **Mohamed EL Habib** : [JENKINS-44489](https://issues.jenkins-ci.org/browse/JENKINS-44489) fixed logout when the plugin is configured to allow READ permission for Authenticated, but not Anonymous users.
  - **Mohamed EL Habib** : add jenkins file to build into ci.jenkins.io
 
 1.1
@@ -24,7 +27,7 @@
 
 1.0.9
 -----------------------------------------------------------------------------------
- - **Jairo Ricarte** : [JENKINS-37741] Testing /project path ont allowGitlabWebHookPermission check
+ - **Jairo Ricarte** : [JENKINS-37741](https://issues.jenkins-ci.org/browse/JENKINS-37741) Testing /project path ont allowGitlabWebHookPermission check
  - **Jairo Ricarte** : added new path for  gitlab-plugin's webhook using anonymous permission
 
 1.0.8
@@ -34,10 +37,10 @@
 1.0.7
 -----------------------------------------------------------------------------------
  - **Mohamed EL HABIB** : remove GitlabGroup.java copied from java-gitlab-api 1.2.6-SNAPSHOT, using released version 1.2.6
- - **wzxjohn** : [JENKINS-37517] Fix login fails because of a GitLab Api Bug Use v1.2.6 of GitLab Api Client to fix this issue.
- - **wzxjohn** : [JENKINS-37518] Fix api url problem New GitLab Api Client will automatically add api/v3 so we do not need to add api/v3 in config. Maybe this config node can be delete in the future.
+ - **wzxjohn** : [JENKINS-37517](https://issues.jenkins-ci.org/browse/JENKINS-37517) Fix login fails because of a GitLab Api Bug Use v1.2.6 of GitLab Api Client to fix this issue.
+ - **wzxjohn** : [JENKINS-37518](https://issues.jenkins-ci.org/browse/JENKINS-37518) Fix api url problem New GitLab Api Client will automatically add api/v3 so we do not need to add api/v3 in config. Maybe this config node can be delete in the future.
  - **wzxjohn** : Fix ERROR: Failed to load help file: Not Found when click the '?' beside "Grant READ permissions for /gitlab-webhook"
- - **wzxjohn** : [JENKINS-37049] License issue
+ - **wzxjohn** : [JENKINS-37049](https://issues.jenkins-ci.org/browse/JENKINS-37049) License issue
 
 1.0.6
 -----------------------------------------------------------------------------------
@@ -45,7 +48,7 @@
 1.0.5
 -----------------------------------------------------------------------------------
  - **Thorsten** : Change HttpClient configuration to drop usage of methods flagged as @deprecated
- - **Jairo Ricarte** : [JENKINS-36075]Gitlab oauth does not display in Security Realm
+ - **Jairo Ricarte** : [JENKINS-36075](https://issues.jenkins-ci.org/browse/JENKINS-36075) Gitlab oauth does not display in Security Realm
 
 1.0.4
 -----------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Jenkins GitLab OAuth Plugin
-
-# Get Latest Package
+![Jenkins Plugins](https://img.shields.io/jenkins/plugin/v/gitlab-oauth)
+![Jenkins Plugin installs](https://img.shields.io/jenkins/plugin/i/gitlab-oauth?color=blue)
+[![Build Status][build-image]][build-link]
+## Get Latest Package
 
     mvn clean package -DskipTests
 
@@ -10,11 +12,11 @@
 -------------
 
 * License: [MIT Licensed](LICENSE.txt)
-* Read more: [GitLab OAuth Plugin wiki page][wiki]
-* Latest build: [![Build Status][build-image]][build-link]
+* Read more: [User Documentation](/docs/README.md)
+* [Changelog](CHANGELOG.md)
 * [Contributions are welcome](CONTRIBUTING.md).
 
-# Overview
+## Overview
 
 The GitLab OAuth plugin provides a means of securing a Jenkins instance by
 offloading authentication and authorization to GitLab.  The plugin authenticates
@@ -23,9 +25,8 @@ authorization strategies for authorizing users.  GitLab users are surfaced as
 Jenkins users for authorization.  GitLab organizations and teams are surfaced as
 Jenkins groups for authorization.
 
-More comprehensive documentation is listed on the [wiki page][wiki].
+More comprehensive documentation is listed on the [user documentation page](/docs/README.md).
 
 [build-image]: https://ci.jenkins.io/buildStatus/icon?job=Plugins/gitlab-oauth-plugin/master
 [build-link]: https://ci.jenkins.io/job/Plugins/job/gitlab-oauth-plugin/job/master/
 [gitlab-wiki-oauth]: http://doc.gitlab.com/ce/api/oauth2.html
-[wiki]: https://wiki.jenkins-ci.org/display/JENKINS/Gitlab+OAuth+Plugin

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jenkins GitLab OAuth Plugin
-![Jenkins Plugins](https://img.shields.io/jenkins/plugin/v/gitlab-oauth)
-![Jenkins Plugin installs](https://img.shields.io/jenkins/plugin/i/gitlab-oauth?color=blue)
+[![Jenkins Plugins](https://img.shields.io/jenkins/plugin/v/gitlab-oauth)](https://plugins.jenkins.io/gitlab-oauth)
+[![Jenkins Plugin installs](https://img.shields.io/jenkins/plugin/i/gitlab-oauth?color=blue)](https://plugins.jenkins.io/gitlab-oauth)
 [![Build Status][build-image]][build-link]
 ## Get Latest Package
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,40 @@
+# GitLab Authentication Plugin
+
+The GitLab Authentication Plugin provides a means of using GitLab for
+authentication and authorization to secure Jenkins. GitLab Enterprise is
+also supported.
+
+## Setup
+
+Before configuring the plugin you must create a GitLab application
+registration. In the Scopes section mark **api**.
+
+the authorization callback URL takes a specific value. It must be
+`http://myserver.example.com:8080/securityRealm/finishLogin` where
+myserver.example.com:8080 is the location of the Jenkins server.
+
+The Client ID and the Client Secret will be used to configure the
+Jenkins Security Realm. Keep the page open to the application
+registration so this information can be copied to your Jenkins
+configuration.
+
+### Security Realm in Global Security
+
+The security realm in Jenkins controls authentication (i.e. you are who
+you say you are). The GitLab Authentication Plugin provides a security
+realm to authenticate Jenkins users via GitLab OAuth.
+
+1.  In the Global Security configuration choose the Security Realm to be
+    **GitLab Authentication Plugin**.
+2.  The settings to configure are: GitLab Web URI, GitLab API URI,
+    Client ID, Client Secret, and OAuth Scope(s).
+3.  If you're using GitLab Enterprise then the API URI is
+    <https://ghe.acme.com/api/v3>. The prefix
+    "[api/v3](https://ghe.acme.com/api/v3){.external-link}" will be
+    completed by the plugin
+
+In the plugin configuration pages each field has a little question mark icon next to it.
+Click on it for help about the setting.
+
+## Version History
+Please refer to the [changelog](/CHANGELOG.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ realm to authenticate Jenkins users via GitLab OAuth.
     Client ID, Client Secret, and OAuth Scope(s).
 3.  If you're using GitLab Enterprise then the API URI is
     <https://ghe.acme.com/api/v3>. The prefix
-    "[api/v3](https://ghe.acme.com/api/v3){.external-link}" will be
+    "[api/v3](https://ghe.acme.com/api/v3)" will be
     completed by the plugin
 
 In the plugin configuration pages each field has a little question mark icon next to it.

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
     <name>Gitlab Authentication plugin</name>
-	<description>A Jenkins authentication plugin that delegates to gitlab.  We also implement an Authorization Strategy that users the acquired OAuth token to interact with the Gitlab API to determine a users level of access to Jenkins.</description>
-	<url>http://wiki.jenkins-ci.org/display/JENKINS/Gitlab+OAuth+Plugin</url>
+    <description>A Jenkins authentication plugin that delegates to gitlab.  We also implement an Authorization Strategy that users the acquired OAuth token to interact with the Gitlab API to determine a users level of access to Jenkins.</description>
+    <url>https://github.com/jenkinsci/gitlab-oauth-plugin/blob/master/docs/README.md</url>
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
     <licenses>
         <license>


### PR DESCRIPTION
Load documentation from GitHub instead of Wiki, see https://issues.jenkins-ci.org/browse/WEBSITE-637