### PR TITLE
Reorder content on the README page to be more user-focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,6 @@
 [![Jenkins Plugins](https://img.shields.io/jenkins/plugin/v/gitlab-oauth)](https://plugins.jenkins.io/gitlab-oauth)
 [![Jenkins Plugin installs](https://img.shields.io/jenkins/plugin/i/gitlab-oauth?color=blue)](https://plugins.jenkins.io/gitlab-oauth)
 [![Build Status][build-image]][build-link]
-## Get Latest Package
-
-    mvn clean package -DskipTests
-
-   Get plugins from `target/gitlab-oauth.hpi`
-
-
--------------
-
-* License: [MIT Licensed](LICENSE.txt)
-* Read more: [User Documentation](/docs/README.md)
-* [Changelog](CHANGELOG.md)
-* [Contributions are welcome](CONTRIBUTING.md).
-
-## Overview
 
 The GitLab OAuth plugin provides a means of securing a Jenkins instance by
 offloading authentication and authorization to GitLab.  The plugin authenticates
@@ -26,6 +11,18 @@ Jenkins users for authorization.  GitLab organizations and teams are surfaced as
 Jenkins groups for authorization.
 
 More comprehensive documentation is listed on the [user documentation page](/docs/README.md).
+
+## Useful links
+
+* License: [MIT Licensed](LICENSE.txt)
+* [User Documentation](/docs/README.md)
+* [Changelog](CHANGELOG.md)
+* [Contributions are welcome](CONTRIBUTING.md).
+
+## Get Latest Package
+
+1. Run `mvn clean package -DskipTests`
+2. Get the plugin HPI from `target/gitlab-oauth.hpi`
 
 [build-image]: https://ci.jenkins.io/buildStatus/icon?job=Plugins/gitlab-oauth-plugin/master
 [build-link]: https://ci.jenkins.io/job/Plugins/job/gitlab-oauth-plugin/job/master/


### PR DESCRIPTION
Was surfing through plugins and noticed this page. Since we are going to use it as a source of plugin documnetation, maybe it makes sense to reorder it a bit to make more user-friendly

CC @zbynek 
