### PR TITLE
Fix group and organisation check.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
@@ -55,6 +55,8 @@ import org.gitlab.api.models.GitlabUser;
 import hudson.security.SecurityRealm;
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
+
 /**
  * @author mocleiri
  *
@@ -297,9 +299,10 @@ public class GitLabAuthenticationToken extends AbstractAuthenticationToken {
 	}
 
 	public GitlabGroup loadOrganization(String organization) {
+		if(StringUtils.isEmpty(organization)) return null;
 		try {
 			if (gitLabAPI != null && isAuthenticated() && !gitLabAPI.getGroups().isEmpty()) {
-				return gitLabAPI.getGroups().get(0); // FIXME return the right group;
+				return gitLabAPI.getGroups().stream().filter(group -> group.getName().contains(organization) || organization.contains(group.getName())).findFirst().orElse(null);
 			}
 		} catch (IOException e) {
 			LOGGER.log(Level.FINEST, e.getMessage(), e);


### PR DESCRIPTION
Fix group check.
We're use Role-based Authorization Strategy and this bug produce unauthorized error on user settings page for credentials plugin button when gitlab user had groups.

