### PR TITLE
Fixed the security problem caused by not qualifying groups…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
@@ -119,9 +119,10 @@ public class GitLabAuthenticationToken extends AbstractAuthenticationToken {
 			List<GitlabGroup> myTeams = gitLabAPI.getGroups();
 			for (GitlabGroup group : myTeams) {
 				LOGGER.log(Level.FINE, "Fetch teams for user " + userName + " in organization " + group.getName());
-				authorities.add(new GrantedAuthorityImpl(group.getName()));
-				authorities.add(new GrantedAuthorityImpl(
-						group + GitLabOAuthGroupDetails.ORG_TEAM_SEPARATOR + group.getName()));
+
+				GitLabOAuthGroupDetails gitLabOAuthGroupDetails = new GitLabOAuthGroupDetails(group);
+
+				authorities.add(gitLabOAuthGroupDetails.getAuth());
 			}
 		}
 	}

--- a/src/main/java/org/jenkinsci/plugins/GitLabOAuthGroupDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabOAuthGroupDetails.java
@@ -3,26 +3,43 @@
  */
 package org.jenkinsci.plugins;
 
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.GrantedAuthorityImpl;
 import org.gitlab.api.models.GitlabGroup;
 
 import hudson.security.GroupDetails;
 
+import java.net.URI;
+
 /**
- * @author Mike
+ * Represent a group from Gitlab as a group in Jenkins terms.
+ *
+ * The surprising bits here are that:
+ * * Gitlab groups exist in a hierarchy while jenkins groups are just a flat namespace
+ * * Jenkins groups live in the same namespace as user names
+ * * Gitlab users can easily be granted the privilege to create new groups and if the name
+ *   of the gitlab group is allowed to become the name of the jenkins group, then a relatively
+ *   low-privilege user in gitlab can create a group that clashes with privileged users and groups
+ *   in jenkins and elevate jenkins privileges that way.
+ *
+ * The solution is two-fold:
+ * * The gitlab groups must be identified as being gitlab groups to avoid clashing with jenkins user names.
+ * * The gitlab group hierarchy must be reflected in the name too, to avoid being able to conflate two groups by name
  *
  */
 public class GitLabOAuthGroupDetails extends GroupDetails {
 
-    private final GitlabGroup org;
+    private final GitlabGroup gitlabGroup;
     static final String ORG_TEAM_SEPARATOR = "*";
+    private String authName;
 
     /**
     * Group based on organization name
-    * @param ghOrg
+    * @param gitlabGroup
     */
-    public GitLabOAuthGroupDetails(GitlabGroup ghOrg) {
+    public GitLabOAuthGroupDetails(GitlabGroup gitlabGroup) {
         super();
-        this.org = ghOrg;
+        this.gitlabGroup = gitlabGroup;
     }
 
     /* (non-Javadoc)
@@ -30,10 +47,51 @@ public class GitLabOAuthGroupDetails extends GroupDetails {
     */
     @Override
     public String getName() {
-        if (org != null) {
-            return org.getName();
+        if (gitlabGroup != null) {
+            return getAuthName();
         }
         return null;
     }
 
+    /**
+     * Construct a globally unique identifier for the group
+     *
+     * The uri for the group is simply stripped of its redundant parts:
+     * * The leading protocol scheme (https://)
+     * * The host name
+     * * The first /groups/ part
+     *
+     * This means that in stead of getting the full url:
+     * https://gitlab.example.com/groups/administrators/supersecret
+     *
+     * You'll get a slightly shorter version:
+     * /administrators/supersecret
+     *
+     * @return The shorter, but still unique id of the group
+     */
+    private synchronized String getAuthName() {
+        if (authName == null) {
+            final String webUrl = gitlabGroup.getWebUrl();
+            authName = shortenGroupUri(webUrl);
+        }
+        return authName;
+    }
+
+    static String shortenGroupUri(String webUrl) {
+        return URI.create(webUrl).getPath().replace("/groups", "");
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Gitlab "+ gitlabGroup.getName()+" ("+getName()+")";
+    }
+
+    @Override
+    public String toString() {
+        return getDisplayName();
+    }
+
+    public GrantedAuthority getAuth() {
+        return new GrantedAuthorityImpl(getName());
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/GitLabOAuthGroupDetailsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/GitLabOAuthGroupDetailsTest.java
@@ -1,0 +1,16 @@
+package org.jenkinsci.plugins;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GitLabOAuthGroupDetailsTest {
+
+    @Test
+    public void shortenGroupUri() {
+        Assert.assertEquals("/admins", GitLabOAuthGroupDetails.shortenGroupUri("http://gitlab.foo.com/groups/admins"));
+        Assert.assertEquals("/admins/baz", GitLabOAuthGroupDetails.shortenGroupUri("http://gitlab.foo.com/groups/admins/baz"));
+        Assert.assertEquals("/admins/baz", GitLabOAuthGroupDetails.shortenGroupUri("https://gitlab.foo.com/groups/admins/baz"));
+    }
+}


### PR DESCRIPTION
… with the parent groups and making sure that groups cannot be conflated with users.

This fixes two separate, but closely related, security problems with the gitlab oauth code:

1: Groups were imported into the same namespace as users in jenkins, so if a user was a member of any group called admin, then he'd get the same privileges as those granted to the user called admin in jenkins.

2: All groups were imported into the same flat namespace, so being a member of bouncyhouse/admin would means that you gained all the same privileges granted to atomic-arsenal/admin, as both would mean that the user was member of the admin group, without an indication of what the parent group was.

There was also a bug in line 123 and 124 of GitLabAuthenticationToken.java that added a useless object refrence to the list of authorities (GitlabGroup@34954fa978f*foo)

This change will break all setups that use gitlab oauth along with Matrix-based or role based security to grant privileges based on gitlab group memberships, but it's the only way to make it secure, sorry.