### PR TITLE
Introduces gitlab groups for admins

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabAuthorizationStrategy.java
@@ -59,6 +59,7 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
             boolean authenticatedUserCreateJobPermission,
             boolean authenticatedUserStopBuildPermission,
             String organizationNames,
+            String adminOrganizationNames,
             boolean allowGitlabWebHookPermission,
             boolean allowCcTrayPermission,
             boolean allowAnonymousReadPermission,
@@ -66,6 +67,7 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
         super();
 
         rootACL = new GitLabRequireOrganizationMembershipACL(adminUserNames,
+                adminOrganizationNames,
                 organizationNames,
                 authenticatedUserReadPermission,
                 useRepositoryPermissions,
@@ -120,6 +122,14 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
      */
     public String getOrganizationNames() {
         return StringUtils.join(rootACL.getOrganizationNameList().iterator(), ", ");
+    }
+
+    /**
+     * @return
+     * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#getAdminOrganizationNameList()
+     */
+    public String getAdminOrganizationNames() {
+        return StringUtils.join(rootACL.getAdminOrganizationNameList().iterator(), ", ");
     }
 
     /**
@@ -205,6 +215,7 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
         if(object instanceof GitLabAuthorizationStrategy) {
             GitLabAuthorizationStrategy obj = (GitLabAuthorizationStrategy) object;
             return this.getOrganizationNames().equals(obj.getOrganizationNames()) &&
+                this.getAdminOrganizationNames().equals(obj.getAdminOrganizationNames()) &&
                 this.getAdminUserNames().equals(obj.getAdminUserNames()) &&
                 this.isUseRepositoryPermissions() == obj.isUseRepositoryPermissions() &&
                 this.isAuthenticatedUserCreateJobPermission() == obj.isAuthenticatedUserCreateJobPermission() &&

--- a/src/main/java/org/jenkinsci/plugins/GitLabRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabRequireOrganizationMembershipACL.java
@@ -54,6 +54,7 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
             .getLogger(GitLabRequireOrganizationMembershipACL.class.getName());
 
     private final List<String> organizationNameList;
+    private final List<String> adminOrganizationNameList;
     private final List<String> adminUserNameList;
     private final boolean authenticatedUserReadPermission;
     private final boolean useRepositoryPermissions;
@@ -87,7 +88,15 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
                 log.finest("Granting Admin rights to user " + candidateName);
                 return true;
             }
-
+            if(this.adminOrganizationNameList != null) {
+                for (String adminOrganizationName : this.adminOrganizationNameList) {
+                    if (authenticationToken.hasOrganizationPermission(candidateName, adminOrganizationName)) {
+                        log.finest("Granting Admin rights to user " +
+                                   candidateName + " a member of " + adminOrganizationName);
+                        return true;
+                    }
+                }
+            }
             if (this.project != null) {
                 if (useRepositoryPermissions) {
                     if(hasRepositoryPermission(authenticationToken, permission)) {
@@ -284,6 +293,7 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
     }
 
     public GitLabRequireOrganizationMembershipACL(String adminUserNames,
+            String adminOrganizationNames,
             String organizationNames,
             boolean authenticatedUserReadPermission,
             boolean useRepositoryPermissions,
@@ -311,6 +321,12 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
             adminUserNameList.add(part.trim());
         }
 
+        this.adminOrganizationNameList = new LinkedList<String>();
+        parts= adminOrganizationNames.split(",");
+        for (String part : parts) {
+            this.adminOrganizationNameList.add(part);
+        }
+
         this.organizationNameList = new LinkedList<String>();
 
         parts = organizationNames.split(",");
@@ -323,6 +339,7 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
     }
 
     public GitLabRequireOrganizationMembershipACL(List<String> adminUserNameList,
+            List<String> adminOrganizationNameList,
             List<String> organizationNameList,
             boolean authenticatedUserReadPermission,
             boolean useRepositoryPermissions,
@@ -336,6 +353,7 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
         super();
 
         this.adminUserNameList                    = adminUserNameList;
+        this.adminOrganizationNameList            = adminOrganizationNameList;
         this.organizationNameList                 = organizationNameList;
         this.authenticatedUserReadPermission      = authenticatedUserReadPermission;
         this.useRepositoryPermissions             = useRepositoryPermissions;
@@ -351,6 +369,7 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
     public GitLabRequireOrganizationMembershipACL cloneForProject(AbstractProject project) {
         return new GitLabRequireOrganizationMembershipACL(
             this.adminUserNameList,
+            this.adminOrganizationNameList,
             this.organizationNameList,
             this.authenticatedUserReadPermission,
             this.useRepositoryPermissions,
@@ -369,6 +388,10 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
 
     public List<String> getAdminUserNameList() {
         return adminUserNameList;
+    }
+
+    public List<String> getAdminOrganizationNameList() {
+        return adminOrganizationNameList;
     }
 
     public boolean isUseRepositoryPermissions() {

--- a/src/main/resources/org/jenkinsci/plugins/GitLabAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GitLabAuthorizationStrategy/config.jelly
@@ -8,6 +8,10 @@
             <f:textbox />
         </f:entry>
 
+        <f:entry title="Gitlab Groups for Admin"  field="adminOrganizationNames" help="/plugin/gitlab-oauth/help/auth/admin-organization-names-help.html">
+            <f:textbox />
+        </f:entry>
+
         <f:entry title="Participant in Organization"  field="organizationNames" help="/plugin/gitlab-oauth/help/auth/organization-names-help.html">
             <f:textbox />
         </f:entry>

--- a/src/main/webapp/help/auth/admin-organization-names-help.html
+++ b/src/main/webapp/help/auth/admin-organization-names-help.html
@@ -1,0 +1,3 @@
+<div>
+Comma Separated list of organization names that if a user is registered with will have admin rights.
+</div>


### PR DESCRIPTION
Great plugin - thanks for providing it.
For our project jenkins we needed the possibility to specify a gitlab group (organization) containing all admins for the jenkins (simplifies the configuration).
So I enhanced the `GitLabRequireOrganizationMembershipACL`  with the property `adminOrganizationNameList` providing exactly the wanted functionality. I tried to be conform with the rest of the code.
Would be nice to have this feature in the official plugin.

Just filed a JIRA issue (see [JENKINS-61382])