### PR TITLE
added hudson.model.Item.Discover permission to read permission checks

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabRequireOrganizationMembershipACL.java
@@ -238,7 +238,8 @@ public class GitLabRequireOrganizationMembershipACL extends ACL {
     private boolean checkReadPermission(Permission permission) {
         if (permission.getId().equals("hudson.model.Hudson.Read")
                 || permission.getId().equals("hudson.model.Item.Workspace")
-                || permission.getId().equals("hudson.model.Item.Read")) {
+                || permission.getId().equals("hudson.model.Item.Read")
+                || permission.getId().equals("hudson.model.Item.Discover")) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
Added `hudson.model.Item.Discover` to `checkReadPermission` as this permission check seems to be neccessary for authenticated (non admin) users when opening the a project details page.