### PR TITLE
Include scope in `/oauth/authorize` URL

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
@@ -187,7 +187,7 @@ public class GitLabAuthenticationToken extends AbstractAuthenticationToken {
 	 *
 	 * @param candidateName
 	 * @param organization
-	 * @return
+	 * @return whether given candidate belongs to a given organization
 	 */
 	public boolean hasOrganizationPermission(String candidateName, String organization) {
 		try {

--- a/src/main/java/org/jenkinsci/plugins/GitLabAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabAuthorizationStrategy.java
@@ -117,7 +117,7 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     /**
-     * @return
+     * @return comma- and space-separated organization names
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#getOrganizationNameList()
      */
     public String getOrganizationNames() {
@@ -125,7 +125,7 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     /**
-     * @return
+     * @return comma- and space-separated admin organization names
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#getAdminOrganizationNameList()
      */
     public String getAdminOrganizationNames() {
@@ -133,7 +133,7 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     /**
-     * @return
+     * @return comma- and space-separated admin usernames
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#getAdminUserNameList()
      */
     public String getAdminUserNames() {
@@ -141,7 +141,6 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     /**
-     * @return
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#isUseRepositoryPermissions()
      */
     public boolean isUseRepositoryPermissions() {
@@ -149,7 +148,6 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     /**
-     * @return
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#isAuthenticatedUserCreateJobPermission()
      */
     public boolean isAuthenticatedUserCreateJobPermission() {
@@ -157,7 +155,6 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     /**
-     * @return
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#isAuthenticatedUserStopBuildPermission()
      */
     public boolean isAuthenticatedUserStopBuildPermission() {
@@ -165,7 +162,6 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     /**
-     * @return
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#isAuthenticatedUserReadPermission()
      */
     public boolean isAuthenticatedUserReadPermission() {
@@ -173,7 +169,6 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     /**
-     * @return
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#isAllowGitlabWebHookPermission()
      */
     public boolean isAllowGitlabWebHookPermission() {
@@ -181,7 +176,6 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
     }
 
     /**
-     * @return
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#isAllowCcTrayPermission()
      */
     public boolean isAllowCcTrayPermission() {
@@ -190,7 +184,6 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
 
 
     /**
-     * @return
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#isAllowAnonymousReadPermission()
      */
     public boolean isAllowAnonymousReadPermission() {
@@ -199,7 +192,6 @@ public class GitLabAuthorizationStrategy extends AuthorizationStrategy {
 
     /**
      * @see org.jenkinsci.plugins.GitLabRequireOrganizationMembershipACL#isAllowAnonymousJobStatusPermission()
-     * @return
      */
     public boolean isAllowAnonymousJobStatusPermission() {
         return rootACL.isAllowAnonymousJobStatusPermission();

--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -284,6 +284,7 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
         parameters.add(new BasicNameValuePair("redirect_uri", buildRedirectUrl(request, redirectOnFinish)));
         parameters.add(new BasicNameValuePair("response_type", "code"));
         parameters.add(new BasicNameValuePair("client_id", clientID));
+        parameters.add(new BasicNameValuePair("scope", "api"));
 
         return new HttpRedirect(gitlabWebUri + "/oauth/authorize?" + URLEncodedUtils.format(parameters, StandardCharsets.UTF_8));
     }

--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -505,7 +505,6 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
     /**
      *
      * @param username
-     * @return
      * @throws UsernameNotFoundException
      * @throws DataAccessException
      */
@@ -562,7 +561,6 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
     /**
      *
      * @param groupName
-     * @return
      * @throws UsernameNotFoundException
      * @throws DataAccessException
      */


### PR DESCRIPTION
As described in Gitlab's guide[1], the parameter should be included,
 otherwise a default set of scopes will be granted, which seems to be
 just `read_user` and is not enough for Jenkins.

According to the README, the plugin needs the `api` scope, so that's
what we're explicitly requesting from Gitlab.

[1] https://docs.gitlab.com/ee/api/oauth2.html#web-application-flow

[JENKINS-63536]

Testing: not yet, hopefully later this week. As described in the JIRA comment, manually modifying the URL fixes the issue.