### PR TITLE
[JEP-227] Prevent Stackoverflow during logout

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -466,7 +466,8 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
         Jenkins jenkins = Jenkins.getInstance();
         assert jenkins != null;
         if (jenkins.hasPermission(Jenkins.READ)) {
-            return super.getPostLogOutUrl(req, auth);
+            // TODO until JEP-227 is merged and core requirement is updated, this will prevent stackoverflow
+            return req.getContextPath() + "/";
         }
         return req.getContextPath() + "/" + GitLabLogoutAction.POST_LOGOUT_URL;
     }


### PR DESCRIPTION
Due to the upcoming changes: https://github.com/jenkinsci/jenkins/pull/4848/files?file-filters%5B%5D=.java&hide-deleted-files=true#diff-7f1293bc6e17d8f944c084eaee7dad62R265-R279 there is an infinite loop when logging out.

Context information: https://github.com/jenkinsci/jep/tree/master/jep/227

@jglick 