### PR TITLE
Fix organization comparison

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
@@ -302,8 +302,11 @@ public class GitLabAuthenticationToken extends AbstractAuthenticationToken {
 	public GitlabGroup loadOrganization(String organization) {
 		if(StringUtils.isEmpty(organization)) return null;
 		try {
-			if (gitLabAPI != null && isAuthenticated() && !gitLabAPI.getGroups().isEmpty()) {
-				return gitLabAPI.getGroups().stream().filter(group -> group.getName().contains(organization) || organization.contains(group.getName())).findFirst().orElse(null);
+			if (gitLabAPI != null && isAuthenticated()) {
+				List<GitlabGroup> gitLabGroups = gitLabAPI.getGroups();
+				if (!gitLabGroups.isEmpty()) {
+					return gitLabGroups.stream().filter(group -> group.getName().equalsIgnoreCase(organization)).findFirst().orElse(null);
+				}
 			}
 		} catch (IOException e) {
 			LOGGER.log(Level.FINEST, e.getMessage(), e);


### PR DESCRIPTION
This code in `getOrganization` uses a combination of `contains` instead of checking for a strict match of the group names. If this code is called for a user in the `not-thegroup` group, `getOranization` might return `thegroup` because

```java
group.getName().contains(organization) || organization.contains(group.getName())
```

would return `true` as `"not-thegroup".contains("thegroup")` is indeed true.

I lack knowledge around the Jenkins and `hudson.security` environments to fully asses the impact of that bug but I felt like this needed to be corrected.

Let me know if I misunderstood something about the plugin!