### PR TITLE
Fix: Changed codebase to use fullPath instead of path for groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,15 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -73,7 +82,7 @@
         <dependency>
             <groupId>org.gitlab</groupId>
             <artifactId>java-gitlab-api</artifactId>
-            <version>4.0.0</version>
+            <version>4.1.1</version>
         </dependency>
 	<dependency>
             <groupId>org.jenkins-ci</groupId>

--- a/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabAuthenticationToken.java
@@ -350,7 +350,7 @@ public class GitLabAuthenticationToken extends AbstractAuthenticationToken {
 
 	public List<GitlabProject> getGroupProjects(final GitlabGroup group) {
 		try {
-			List<GitlabProject> groupProjects = groupRepositoriesCache.get(group.getPath(), new Callable<List<GitlabProject>>() {
+			List<GitlabProject> groupProjects = groupRepositoriesCache.get(group.getFullPath(), new Callable<List<GitlabProject>>() {
 				@Override
 				public List<GitlabProject> call() throws Exception {
 					return gitLabAPI.getGroupProjects(group);

--- a/src/main/java/org/jenkinsci/plugins/GitLabOAuthGroupDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabOAuthGroupDetails.java
@@ -47,7 +47,7 @@ public class GitLabOAuthGroupDetails extends GroupDetails {
     @Override
     public String getName() {
         if (gitlabGroup != null) {
-            return gitlabGroup.getPath();
+            return gitlabGroup.getFullPath();
         }
         return null;
     }


### PR DESCRIPTION
Pull request #29 broke support for nested groups.

This pull request fixes #29 and it also fixes similar namespace issue from GitLabAuthenticationToken. Update of GitLab API was dependency was required