### PR TITLE
[JENKINS-66303] Prepare Gitlab Authentication for core Guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,10 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>caffeine-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
         </dependency>


### PR DESCRIPTION
See [JENKINS-66303](https://issues.jenkins.io/browse/JENKINS-66303) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.cache.Cache#get(K key)` API, which has been removed between Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/cache/Cache.html) and [latest](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/cache/Cache.html). The removal took place in Guava 12.0.

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. The recommendation is for plugins to migrate from Guava's cache to [Caffeine](https://github.com/ben-manes/caffeine) via the Jenkins [Caffeine API](https://plugins.jenkins.io/caffeine-api/) plugin.

For the most part, the migration is a trivial matter of replacing imports of `com.google.common.cache.Cache` with imports of `com.github.benmanes.caffeine.cache.Cache` and imports of `com.google.common.cache.CacheBuilder` with imports of `com.github.benmanes.caffeine.cache.Caffeine`.

**Untested.**

CC @mohamedelhabib