### PR TITLE
Use SLF4J from Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,6 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.8.0-beta2</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -102,6 +97,12 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.datatype</groupId>
                     <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+
+                <!-- Provided by Jenkins core -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
As an alternative to #34, just rely on the copy of this library that Jenkins core already ships.