### PR TITLE
Encrypt stored client secret value

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
+import hudson.util.Secret;
 import jenkins.security.SecurityListener;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.AuthenticationException;
@@ -59,6 +60,7 @@ import org.gitlab.api.models.GitlabGroup;
 import org.gitlab.api.models.GitlabUser;
 import org.jfree.util.Log;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.Header;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
@@ -103,7 +105,7 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
     private String gitlabWebUri;
     private String gitlabApiUri;
     private String clientID;
-    private String clientSecret;
+    private Secret clientSecret;
 
     /**
      * @param gitlabWebUri
@@ -116,6 +118,8 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
      *            The client ID for the created OAuth Application.
      * @param clientSecret
      *            The client secret for the created GitLab OAuth Application.
+     *            Should be encrypted value of a {@link hudson.util.Secret},
+     *            for compatibility also plain text values are accepted.
      */
     @DataBoundConstructor
     public GitLabSecurityRealm(String gitlabWebUri, String gitlabApiUri, String clientID, String clientSecret) {
@@ -124,7 +128,7 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
         this.gitlabWebUri = Util.fixEmptyAndTrim(gitlabWebUri);
         this.gitlabApiUri = Util.fixEmptyAndTrim(gitlabApiUri);
         this.clientID = Util.fixEmptyAndTrim(clientID);
-        this.clientSecret = Util.fixEmptyAndTrim(clientSecret);
+        setClientSecret(Util.fixEmptyAndTrim(clientSecret));
     }
 
     private GitLabSecurityRealm() {
@@ -152,7 +156,7 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
      *            the clientSecret to set
      */
     private void setClientSecret(String clientSecret) {
-        this.clientSecret = clientSecret;
+        this.clientSecret = Secret.fromString(clientSecret);
     }
 
     /**
@@ -195,7 +199,7 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
             writer.endNode();
 
             writer.startNode("clientSecret");
-            writer.setValue(realm.getClientSecret());
+            writer.setValue(realm.clientSecret.getEncryptedValue());
             writer.endNode();
         }
 
@@ -254,13 +258,6 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
         return clientID;
     }
 
-    /**
-     * @return the clientSecret
-     */
-    public String getClientSecret() {
-        return clientSecret;
-    }
-
     // "from" is coming from SecurityRealm/loginLink.jelly
     public HttpResponse doCommenceLogin(StaplerRequest request, @QueryParameter String from, @Header("Referer") final String referer) throws IOException {
         // 2. Requesting authorization :
@@ -305,11 +302,15 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
             Log.info("doFinishLogin: missing code or private_token.");
             return HttpResponses.redirectToContextRoot();
         }
+        if (clientSecret == null) {
+            Log.info("doFinishLogin: missing client secret.");
+            return HttpResponses.redirectToContextRoot();
+        }
         String referer = (String)request.getSession().getAttribute(REFERER_ATTRIBUTE);
         HttpPost httpPost = new HttpPost(gitlabWebUri + "/oauth/token");
         List<NameValuePair> parameters = new ArrayList<>();
         parameters.add(new BasicNameValuePair("client_id", clientID));
-        parameters.add(new BasicNameValuePair("client_secret", clientSecret));
+        parameters.add(new BasicNameValuePair("client_secret", clientSecret.getPlainText()));
         parameters.add(new BasicNameValuePair("code", code));
         parameters.add(new BasicNameValuePair("grant_type", "authorization_code"));
         parameters.add(new BasicNameValuePair("redirect_uri", buildRedirectUrl(request)));
@@ -540,7 +541,7 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
         if (object instanceof GitLabSecurityRealm) {
             GitLabSecurityRealm obj = (GitLabSecurityRealm) object;
             return this.getGitlabWebUri().equals(obj.getGitlabWebUri()) && this.getGitlabApiUri().equals(obj.getGitlabApiUri()) && this.getClientID().equals(obj.getClientID())
-                    && this.getClientSecret().equals(obj.getClientSecret());
+                    && this.clientSecret.equals(obj.clientSecret);
         } else {
             return false;
         }

--- a/src/main/resources/org/jenkinsci/plugins/GitLabSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GitLabSecurityRealm/config.jelly
@@ -17,7 +17,7 @@
         </f:entry>
 
         <f:entry title="Client Secret" field="clientSecret" help="/plugin/gitlab-oauth/help/realm/client-secret-help.html">
-            <f:textbox />
+            <f:password />
         </f:entry>
 
     </f:section>


### PR DESCRIPTION
Fixes https://issues.jenkins.io/browse/SECURITY-1891 from [security advisory](https://www.jenkins.io/security/advisory/2022-03-15/)

When serializing, the encrypted value is used. Deserialization checks if the string is in format `{encrypted}` and treats it as encrypted or plain text accordingly.

This includes changes from https://github.com/jenkinsci/gitlab-oauth-plugin/pull/58 so that the CI build can be downloaded and used for fixing both vulnerabilities.

CC @jvz @Wadeck 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
