### PR TITLE
Add client secret getter for jelly

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -28,6 +28,7 @@ import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import hudson.util.Secret;
@@ -256,6 +257,14 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
      */
     public String getClientID() {
         return clientID;
+    }
+
+    /**
+     * Used by jelly
+     * @return the client secret
+     */
+    public Secret getClientSecret() {
+        return clientSecret;
     }
 
     // "from" is coming from SecurityRealm/loginLink.jelly

--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -28,7 +28,6 @@ import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.logging.Logger;
 
 import hudson.util.Secret;
@@ -61,7 +60,6 @@ import org.gitlab.api.models.GitlabGroup;
 import org.gitlab.api.models.GitlabUser;
 import org.jfree.util.Log;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.Header;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;


### PR DESCRIPTION
Amends #59 -- there I removed the getter (assuming it was better not to expose the secret via public method), but it's needed for the Jelly controls to work correctly. Without it, clicking "save" in global configuration without making any changes will store empty secret to config, locking everybody out. Sorry for the mess!

@basil could you please release this soon?