### PR TITLE
remove useless char "?" at the end of redirect_uri

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -290,10 +290,9 @@ public class GitLabSecurityRealm extends SecurityRealm implements UserDetailsSer
 
     private String buildRedirectUrl(StaplerRequest request) throws MalformedURLException {
         URL currentUrl = new URL(Jenkins.get().getRootUrl());
-        List<NameValuePair> parameters = new ArrayList<>();
 
         URL redirect_uri = new URL(currentUrl.getProtocol(), currentUrl.getHost(), currentUrl.getPort(),
-                request.getContextPath() + "/securityRealm/finishLogin?" + URLEncodedUtils.format(parameters, StandardCharsets.UTF_8));
+                request.getContextPath() + "/securityRealm/finishLogin");
         return redirect_uri.toString();
     }
 


### PR DESCRIPTION
it's not compatible with gitlab-ce 12.5, gitlab will return 401 when trying to get access_token.

<!-- Please describe your pull request here. -->

### Testing done
I tested it with gitlab 12.5 and 16.1

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
