### PR TITLE
Use checkstyle for Java 11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,16 @@
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+---
 version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    labels:
+      - "dependencies"
     schedule:
       interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels:
+      - "skip-changelog"
     schedule:
       interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    ignore:
-      # Starting with version 10.0, this library requires Java 11
-      - dependency-name: "com.puppycrawl.tools:checkstyle"
-        versions: [">=10.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>9.3</version>
+                        <version>10.12.3</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
## Use checkstyle for Java 11

- Use checkstyle 10 now that we require Java 11
- Label dependabot pull requests

### Testing done

The checkstyle output continues silent when I run `mvn checkstyle:checkstyle`.  Will confirm with ci.jenkins.io as well.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
