### PR TITLE
Update gitlab-api to 5.8.1-106.vef1de800710e

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <revision>1.23</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.baseline>2.492</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>5054.v620b_5d2b_d5e6</version>
+                <version>5422.v0fce72a_b_b_8cf</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -89,6 +89,8 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>gitlab-api</artifactId>
+            <!-- To remove when on bom -->
+            <version>5.8.1-106.vef1de800710e</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Normally just updating gitlab-api should be enough

But better to ensure minimum version and directly bump to supported bom version

Related to https://github.com/jenkinsci/gitlab-oauth-plugin/issues/195

### Testing done

mvn clean install

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
