### PR TITLE
chore: Revert checkstyle 13.3.0 bump and add Java 17 to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,4 +7,5 @@ buildPlugin(
   configurations: [
     [platform: 'linux', jdk: 25],
     [platform: 'windows', jdk: 21],
+    [platform: 'linux', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>13.3.0</version>
+                        <version>13.0.0</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>13.0.0</version>
+                        <version>12.3.1</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
## Summary

- Reverts checkstyle from 13.3.0 back to 13.0.0. Version 13.3.0 requires Java 21 (class file version 65.0) which breaks the plugin BOM tests running on Java 17
- Adds a `[platform: 'linux', jdk: 17]` configuration to the Jenkinsfile

## Context

As reported by @MarkEWaite in #215, the checkstyle 13.3.0 bump is causing BOM test failures:
- https://github.com/jenkinsci/bom/pull/6432#issuecomment-3992597198

The error: `UnsupportedClassVersionError: com/puppycrawl/tools/checkstyle/api/CheckstyleException has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0`

Class file version 65.0 = Java 21; the BOM environment tests Java 17 too (version 61.0).

## Test plan

- [x] CI passes with reverted checkstyle version
- [x] Java 17 configuration is exercised in CI

cc @MarkEWaite @krisstern; once merged, a new release would be needed to fix the weekly BOM build.