### PR TITLE
Read API scope support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,10 @@ also supported.
 ## Setup
 
 Before configuring the plugin you must create a GitLab application
-registration. In the Scopes section mark **api**.
+registration. In the Scopes section mark **read_api** (recommended) or
+**api**.
 
-the authorization callback URL takes a specific value. It must be
+The authorization callback URL takes a specific value. It must be
 `http://myserver.example.com:8080/securityRealm/finishLogin` where
 myserver.example.com:8080 is the location of the Jenkins server.
 
@@ -28,8 +29,9 @@ realm to authenticate Jenkins users via GitLab OAuth.
     **GitLab Authentication Plugin**.
 2.  The settings to configure are: GitLab Web URI, GitLab API URI,
     Client ID, Client Secret, and OAuth Scope(s).
-3.  If you're using GitLab Enterprise then the API URI is
-    <https://ghe.acme.com/api/v3>. The prefix
+3.  Select the scope configured during GitLab application registration in the **OAuth Scope(s)** dropdown.
+4.  If you're using GitLab Enterprise then the API URI is
+    <https://ghe.acme.com/api/v3>. The prefix
     "[api/v3](https://ghe.acme.com/api/v3)" will be
     completed by the plugin
 

--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -77,6 +77,7 @@ import org.gitlab4j.api.models.Group;
 import org.gitlab4j.models.Constants.TokenType;
 import org.jfree.util.Log;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.Header;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
@@ -107,6 +108,7 @@ public class GitLabSecurityRealm extends SecurityRealm {
     private String gitlabApiUri;
     private String clientID;
     private Secret clientSecret;
+    private String scope = "api";
 
     /**
      * @param gitlabWebUri
@@ -199,6 +201,10 @@ public class GitLabSecurityRealm extends SecurityRealm {
             writer.startNode("clientSecret");
             writer.setValue(realm.clientSecret.getEncryptedValue());
             writer.endNode();
+
+            writer.startNode("scope");
+            writer.setValue(realm.getScope());
+            writer.endNode();
         }
 
         @Override
@@ -234,6 +240,9 @@ public class GitLabSecurityRealm extends SecurityRealm {
                 case "gitlabapiuri":
                     realm.setGitlabApiUri(value);
                     break;
+                case "scope":
+                    realm.setScope(value);
+                    break;
                 default:
                     throw new ConversionException("Invalid node value = " + node);
             }
@@ -263,6 +272,15 @@ public class GitLabSecurityRealm extends SecurityRealm {
         return clientSecret;
     }
 
+    public String getScope() {
+        return StringUtils.isNotBlank(scope) ? scope : "api";
+    }
+
+    @DataBoundSetter
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
     // "from" is coming from SecurityRealm/loginLink.jelly
     public HttpResponse doCommenceLogin(
             StaplerRequest2 request, @QueryParameter String from, @Header("Referer") final String referer)
@@ -290,7 +308,7 @@ public class GitLabSecurityRealm extends SecurityRealm {
         parameters.add(new BasicNameValuePair("redirect_uri", buildRedirectUrl(request)));
         parameters.add(new BasicNameValuePair("response_type", "code"));
         parameters.add(new BasicNameValuePair("client_id", clientID));
-        parameters.add(new BasicNameValuePair("scope", "api"));
+        parameters.add(new BasicNameValuePair("scope", getScope()));
         parameters.add(new BasicNameValuePair("state", state));
 
         return new HttpRedirect(
@@ -588,6 +606,7 @@ public class GitLabSecurityRealm extends SecurityRealm {
             return this.getGitlabWebUri().equals(obj.getGitlabWebUri())
                     && this.getGitlabApiUri().equals(obj.getGitlabApiUri())
                     && this.getClientID().equals(obj.getClientID())
+                    && this.getScope().equals(obj.getScope())
                     && this.clientSecret.equals(obj.clientSecret);
         } else {
             return false;

--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -550,6 +550,13 @@ public class GitLabSecurityRealm extends SecurityRealm {
         public DescriptorImpl(Class<? extends SecurityRealm> clazz) {
             super(clazz);
         }
+
+        public hudson.util.ListBoxModel doFillScopeItems() {
+            hudson.util.ListBoxModel items = new hudson.util.ListBoxModel();
+            items.add("api", "api");
+            items.add("read_api", "read_api");
+            return items;
+        }
     }
 
     // Overridden for better type safety.

--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -43,6 +43,7 @@ import hudson.security.GroupDetails;
 import hudson.security.SecurityRealm;
 import hudson.security.UserMayOrMayNotExistException2;
 import hudson.tasks.Mailer;
+import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
@@ -273,7 +274,7 @@ public class GitLabSecurityRealm extends SecurityRealm {
     }
 
     public String getScope() {
-        return StringUtils.isNotBlank(scope) ? scope : "api";
+        return scope;
     }
 
     @DataBoundSetter
@@ -551,8 +552,8 @@ public class GitLabSecurityRealm extends SecurityRealm {
             super(clazz);
         }
 
-        public hudson.util.ListBoxModel doFillScopeItems() {
-            hudson.util.ListBoxModel items = new hudson.util.ListBoxModel();
+        public ListBoxModel doFillScopeItems() {
+            ListBoxModel items = new ListBoxModel();
             items.add("api", "api");
             items.add("read_api", "read_api");
             return items;

--- a/src/main/resources/org/jenkinsci/plugins/GitLabSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GitLabSecurityRealm/config.jelly
@@ -20,8 +20,8 @@
             <f:password />
         </f:entry>
 
-        <f:entry title="OAuth Scope(s)" field="scope">
-            <f:textbox default="api" />
+        <f:entry title="OAuth Scope(s)" field="scope" help="/plugin/gitlab-oauth/help/realm/scope-help.html">
+            <f:select default="api" />
         </f:entry>
 
     </f:section>

--- a/src/main/resources/org/jenkinsci/plugins/GitLabSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GitLabSecurityRealm/config.jelly
@@ -20,5 +20,9 @@
             <f:password />
         </f:entry>
 
+        <f:entry title="OAuth Scope(s)" field="scope">
+            <f:textbox default="api" />
+        </f:entry>
+
     </f:section>
 </j:jelly>

--- a/src/main/webapp/help/realm/scope-help.html
+++ b/src/main/webapp/help/realm/scope-help.html
@@ -1,5 +1,5 @@
 <div>
-  The <b>Token Scope</b> from the gitlab application entry being configured. Recommended value: <strong>read_api</strong>.
+  The <b>Token Scope</b> from the GitLab application entry being configured. Recommended value: <strong>read_api</strong>.
   <ul>
     <li><strong>api:</strong> Full read/write access to the GitLab API. (Legacy support)</li>
     <li><strong>read_api:</strong> Read-only access to the GitLab API. (Recommended)</li>

--- a/src/main/webapp/help/realm/scope-help.html
+++ b/src/main/webapp/help/realm/scope-help.html
@@ -1,7 +1,7 @@
 <div>
-  Select the OAuth scope required by this Jenkins instance.
+  The <b>Token Scope</b> from the gitlab application entry being configured. Recommended value: <strong>read_api</strong>.
   <ul>
-    <li><strong>api:</strong> Full read/write access to the GitLab API. Required if you need this plugin or other plugins to actively manage repository states.</li>
-    <li><strong>read_api:</strong> Read-only access to the GitLab API. Recommended to follow the principle of least privilege if write access is not required.</li>
+    <li><strong>api:</strong> Full read/write access to the GitLab API. (Legacy support)</li>
+    <li><strong>read_api:</strong> Read-only access to the GitLab API. (Recommended)</li>
   </ul>
 </div>

--- a/src/main/webapp/help/realm/scope-help.html
+++ b/src/main/webapp/help/realm/scope-help.html
@@ -1,0 +1,7 @@
+<div>
+  Select the OAuth scope required by this Jenkins instance.
+  <ul>
+    <li><strong>api:</strong> Full read/write access to the GitLab API. Required if you need this plugin or other plugins to actively manage repository states.</li>
+    <li><strong>read_api:</strong> Read-only access to the GitLab API. Recommended to follow the principle of least privilege if write access is not required.</li>
+  </ul>
+</div>


### PR DESCRIPTION
Feature enhancement for #118 
Added a scope configuration property replacing hard-coded 'api' to allow customizing the OAuth scopes requested during login.
Added an "OAuth Scope" dropdown menu.
Added a dedicated help.html,
The default choice safely remains api to preserve backwards compatibility.

### Testing done
Verified backwards compatibility for api and tested read_api scoped client token by installing the packaged hpi into an existing jenkins controller. 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed