### PR TITLE
Throw checked exception when password authentication fails

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GitLabSecurityRealm.java
@@ -470,16 +470,14 @@ public class GitLabSecurityRealm extends SecurityRealm {
                         if (authentication instanceof GitLabAuthenticationToken) {
                             return authentication;
                         }
-                        if (authentication instanceof UsernamePasswordAuthenticationToken) {
+                        if (authentication instanceof UsernamePasswordAuthenticationToken token) {
                             try {
-                                UsernamePasswordAuthenticationToken token =
-                                        (UsernamePasswordAuthenticationToken) authentication;
                                 GitLabAuthenticationToken gitlab = new GitLabAuthenticationToken(
                                         token.getCredentials().toString(), getGitlabApiUri(), TokenType.PRIVATE);
                                 SecurityContextHolder.getContext().setAuthentication(gitlab);
                                 return gitlab;
                             } catch (GitLabApiException e) {
-                                throw new RuntimeException(e);
+                                throw new BadCredentialsException("Authentication failed", e);
                             }
                         }
                         throw new BadCredentialsException("Unexpected authentication type: " + authentication);


### PR DESCRIPTION
Changes exception from unchecked to checked when basic auth access it attempted.

At the moment, accessing the server with (invalid) basic authentication results in long stacktrace in the logs:

```
org.gitlab4j.api.GitLabApiException: 401 Unauthorized
	at PluginClassLoader for gitlab-api//org.gitlab4j.api.AbstractApi.validate(AbstractApi.java:784)
	at PluginClassLoader for gitlab-api//org.gitlab4j.api.AbstractApi.get(AbstractApi.java:262)
	at PluginClassLoader for gitlab-api//org.gitlab4j.api.UserApi.getCurrentUser(UserApi.java:700)
	at PluginClassLoader for gitlab-oauth//org.jenkinsci.plugins.GitLabAuthenticationToken.<init>(GitLabAuthenticationToken.java:101)
	at PluginClassLoader for gitlab-oauth//org.jenkinsci.plugins.GitLabSecurityRealm$1.authenticate(GitLabSecurityRealm.java:478)
Caused: java.lang.RuntimeException
	at PluginClassLoader for gitlab-oauth//org.jenkinsci.plugins.GitLabSecurityRealm$1.authenticate(GitLabSecurityRealm.java:482)
	at jenkins.security.BasicHeaderRealPasswordAuthenticator.authenticate2(BasicHeaderRealPasswordAuthenticator.java:60)
	at jenkins.security.BasicHeaderProcessor.doFilter(BasicHeaderProcessor.java:92)
	at hudson.security.ChainedServletFilter2$1.doFilter(ChainedServletFilter2.java:99)
	at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:117)
	at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:87)
	at hudson.security.HttpSessionContextIntegrationFilter2.doFilter(HttpSessionContextIntegrationFilter2.java:63)
	at hudson.security.ChainedServletFilter2$1.doFilter(ChainedServletFilter2.java:99)
	at hudson.security.ChainedServletFilter2.doFilter(ChainedServletFilter2.java:111)
	at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:173)
```

Avoiding the use of unchecked exception fixes it.

### Testing done

TBD

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
