### PR TITLE
Use GitLab API from BOM, remove incrementals repo from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,6 @@
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
-        <repository>
-            <id>incrementals</id>
-            <url>https://repo.jenkins-ci.org/incrementals/</url>
-        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -99,7 +95,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>gitlab-api</artifactId>
-            <version>6.2.0-125.v4b_82966387db_</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
The incrementals repository was added to POM in my previous PR to allow using incremental gitlab API.
It should be removed so that Dependabot does not offer incremental dependencies (that happened in #226).
Also the `gitlab-api` version in BOM is now sufficient for this plugin to work correctly.

### Testing done

TBD

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
